### PR TITLE
AlreadyTappedError printed as warning.

### DIFF
--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -10,7 +10,11 @@ module Homebrew extend self
     elsif ARGV.first == "--repair"
       repair_taps
     else
-      install_tap(*tap_args)
+      begin
+        install_tap(*tap_args)
+      rescue AlreadyTappedError
+        opoo "#{ARGV.first} already tapped"
+      end
     end
   end
 


### PR DESCRIPTION
It is natural to place idempotent operations in Brewfiles, such as installation of formulas that might already installed, and tapping of taps that might already tapped.  The execution of idempotent operations should consistently print Warning-level messages, versus a mix of Warning- and Error-level messages.  This way, users can more safely ignore warnings when they execute a Brewfile but be paranoid when an Error is printed.

While "brew install" of an already installed formula currently prints a Warning, "brew tap" of an already tapped Tap issues an Error message.  This patch to cmd/tap.rb changes this behavior to issue a Warning when re-tapping a Tap, which makes "brew tap" more consistent with "brew install", and more friendly to Brewfiles.
